### PR TITLE
Improve Layout

### DIFF
--- a/frontend/src/app/about/features/features.component.html
+++ b/frontend/src/app/about/features/features.component.html
@@ -1,5 +1,4 @@
-<div class="d-flex justify-content-center text-center">
-  <div class="col-6 justify-content-center">
+<div class="container text-center">
     <table class="table table-bordered">
       <thead class="thead-color">
       <tr>
@@ -154,5 +153,4 @@
       </tr>
       </tbody>
     </table>
-  </div>
 </div>

--- a/frontend/src/app/poll/choose-date/choose-date.component.html
+++ b/frontend/src/app/poll/choose-date/choose-date.component.html
@@ -1,23 +1,16 @@
-<div class="container mt-4">
-  <div class="row">
-    <div class="col-md-6">
-      <div class="btn-group">
+<div class="container mt-3">
+  <div class="d-flex align-items-center mb-3">
+      <div class="btn-group me-auto">
         <div class="btn btn-primary" mwlCalendarPreviousView [view]="'week'" [(viewDate)]="viewDate">Previous</div>
-        <div class="btn btn-primary" mwlCalendarToday [(viewDate)]="viewDate" (click)="scrollToCurrentTime()">Today
-        </div>
+        <div class="btn btn-primary" mwlCalendarToday [(viewDate)]="viewDate" (click)="scrollToCurrentTime()">Today</div>
         <div class="btn btn-primary" mwlCalendarNextView [view]="'week'" [(viewDate)]="viewDate">Next</div>
       </div>
-    </div>
-    <div class="col-md-6 d-flex justify-content-end">
-      <div class="btn-group">
+      <div class="btn-group me-2">
         <button type="button" class="btn btn-primary" routerLink="postpone">Postpone</button>
         <button type="button" class="btn btn-primary" routerLink="custom-definition">Custom definition</button>
       </div>
-      <h3 class="mx-2">{{ viewDate | calendarDate:('weekViewTitle') }}</h3>
-    </div>
+      <h3 class="mb-0">{{ viewDate | calendarDate:('weekViewTitle') }}</h3>
   </div>
-  <br/>
-
   <ng-template
     #weekViewHourSegmentTemplate
     let-segment="segment"
@@ -38,8 +31,7 @@
       </div>
     </div>
   </ng-template>
-
-  <div class="scroll-container">
+  <div class="scroll-container border border-primary shadow mb-3">
     <mwl-calendar-week-view
       [viewDate]="viewDate"
       [events]="getEvents()"
@@ -51,7 +43,7 @@
     >
     </mwl-calendar-week-view>
   </div>
-  <div class="d-flex justify-content-end mt-2">
+  <div class="d-flex justify-content-end">
     <div *ngIf="!hasEvents()" class="btn btn-primary" (click)="createEvents()">Create</div>
     <div *ngIf="hasEvents()" class="btn btn-primary" (click)="createEvents()">Update</div>
   </div>

--- a/frontend/src/app/poll/choose-date/choose-date.component.scss
+++ b/frontend/src/app/poll/choose-date/choose-date.component.scss
@@ -1,7 +1,5 @@
 .scroll-container {
   height: calc(100vh - 258px);
-  border: 1px solid #5a189aff;
-  box-shadow: 0 0 15px rgba(0, 0, 0, .1);
 }
 
 .btn-group .btn {

--- a/frontend/src/app/poll/choose-events/choose-events.component.html
+++ b/frontend/src/app/poll/choose-events/choose-events.component.html
@@ -1,5 +1,4 @@
-<div class="d-flex justify-content-center">
-  <div class="col-6 justify-content-center">
+<div class="container">
     <div *ngIf="mail.length <= 0" class="d-flex align-items-center justify-content-center pt-5">
       <h3>
         You seem to have no mail configured. Press:
@@ -199,6 +198,5 @@
         </table>
       </form>
     </div>
-  </div>
 </div>
 <ngbx-toast-list></ngbx-toast-list>

--- a/frontend/src/app/poll/create-poll/create-edit-poll.component.html
+++ b/frontend/src/app/poll/create-poll/create-edit-poll.component.html
@@ -1,7 +1,6 @@
-<div class="d-flex justify-content-center">
-  <div *ngIf="!id || isAdmin()" class="col-6 justify-content-center">
-    <form class="m-5" [formGroup]="pollForm" (ngSubmit)="onFormSubmit()">
-      <div *ngIf="id" class="d-flex justify-content-end pt-3">
+<div *ngIf="!id || isAdmin()" class="container mt-3">
+    <form [formGroup]="pollForm" (ngSubmit)="onFormSubmit()">
+      <div *ngIf="id" class="mb-3 d-flex justify-content-end">
         <button
           type="button"
           class="btn btn-primary rounded-0 bi-pencil-square btn-mini"
@@ -24,7 +23,7 @@
           ngbTooltip="Delete poll"
         ></button>
       </div>
-      <div class="container settings-box">
+      <div class="mb-3 p-3 border border-primary shadow">
         <div class="form-group mb-3">
           <label for="title">Title</label>
           <input class="form-control" type="text" id="title" placeholder="Name of the event" formControlName="title">
@@ -123,14 +122,13 @@
         </div>
       </div>
       <div class="d-flex justify-content-end">
-        <button type="button" class="btn btn-outline-secondary" (click)="onCancel()">Cancel</button>
+        <button type="button" class="btn btn-outline-secondary me-2" (click)="onCancel()">Cancel</button>
         <button *ngIf="!id" class="btn btn-primary" type="submit" [disabled]="!pollForm.valid">Create</button>
         <button *ngIf="id" class="btn btn-primary" type="submit" [disabled]="!pollForm.valid || !pollForm.dirty">
           Update
         </button>
       </div>
     </form>
-  </div>
 </div>
 
 <ng-template #content let-modal>

--- a/frontend/src/app/poll/create-poll/create-edit-poll.component.html
+++ b/frontend/src/app/poll/create-poll/create-edit-poll.component.html
@@ -45,17 +45,19 @@
         </div>
         <div class="form-group mb-3">
           <label for="deadline">Deadline (optional)</label>
-          <div class="d-flex">
+          <div class="input-group">
             <input type="date" id="deadline" class="form-control" formControlName="deadlineDate">
             <input type="time" class="form-control" formControlName="deadlineTime">
           </div>
         </div>
         <button type="button"
                 class="btn btn-outline-primary"
+                [class.bi-chevron-right]="isCollapsed"
+                [class.bi-chevron-down]="!isCollapsed"
                 (click)="collapse.toggle()"
                 [attr.aria-expanded]="!isCollapsed"
                 aria-controls="collapseExample">
-          Additional options
+          Additional Options
         </button>
         <div class="pt-3" #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed">
           <div class="form-group form-check">

--- a/frontend/src/app/poll/create-poll/create-edit-poll.component.scss
+++ b/frontend/src/app/poll/create-poll/create-edit-poll.component.scss
@@ -1,9 +1,3 @@
 .mwlFlatpickr {
   width: 100%;
 }
-
-.settings-box {
-  border: 1px solid #5a189aff;
-  box-shadow: 0 0 15px rgba(0, 0, 0, .1);
-  padding: 20px;
-}


### PR DESCRIPTION
I changed the layout in many pages to use `.container`, because it works better on mobile. Also I simplified some CSS and added an icon for the Additional Options button to indicate it expands and collapses.

Note that most lines would be changed/de-indented by reformat. I wanted to avoid merge conflicts.

