### PR TITLE
Fix a few CI warnings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "name=pnpm_cache_dir::$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build the Docker Image
         uses: whoan/docker-build-with-cache-action@v5
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "name=pnpm_cache_dir::$(pnpm store path)" >> $GITHUB_OUTPUT
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
# Context
The [current workflow](https://github.com/Morphclue/apollusia/actions/runs/3552666443) has some warnings (8 in total) and I hope that with this PR I can reduce some of them.

### set-output
If i understood it correctly the warning `The `set-output` command is deprecated and will be disabled soon.` can be fixed by turning every
```sh
echo "::set-output name=KEY::VALUE"
```
into
```sh
echo "KEY=VALUE" >> $GITHUB_OUTPUT
```

### Node.js 12 actions
Won't be fully fixed with this, but at least partially.
The mentioned deprecated actions in the warning `Node.js 12 actions are deprecated.` are `actions/checkout@v2`  and `sekassel-research/actions-rancher-update@2.0.2`. Therefore I've updated the checkout-action to `actions/checkout@v3`.