### PR TITLE
Add participant-token header

### DIFF
--- a/backend/src/poll/poll/poll.controller.ts
+++ b/backend/src/poll/poll/poll.controller.ts
@@ -1,4 +1,4 @@
-import {Body, Controller, Delete, Get, NotFoundException, Param, Post, Put} from '@nestjs/common';
+import {Body, Controller, Delete, Get, Headers, NotFoundException, Param, Post, Put} from '@nestjs/common';
 import {Types} from 'mongoose';
 
 import {MailDto, ParticipantDto, PollDto, PollEventDto, ReadParticipantDto} from '../../dto';
@@ -81,8 +81,11 @@ export class PollController {
     }
 
     @Get(':id/participate')
-    async getParticipants(@Param('id') id: string): Promise<ReadParticipantDto[]> {
-        return this.pollService.getParticipants(id);
+    async getParticipants(
+        @Param('id') id: string,
+        @Headers('Participant-Token') token: string,
+    ): Promise<ReadParticipantDto[]> {
+        return this.pollService.getParticipants(id, token);
     }
 
     @Post(':id/participate')

--- a/backend/src/poll/poll/poll.service.ts
+++ b/backend/src/poll/poll/poll.service.ts
@@ -116,8 +116,16 @@ export class PollService {
         return await this.pollEventModel.find({poll: new Types.ObjectId(id)}).exec();
     }
 
-    async getParticipants(id: string): Promise<ReadParticipantDto[]> {
-        return this.participantModel.find({poll: new Types.ObjectId(id)}).select(readParticipantSelect).exec();
+    async getParticipants(id: string, token: string): Promise<ReadParticipantDto[]> {
+        const participants = await this.participantModel.find({
+            poll: new Types.ObjectId(id),
+            token: {$ne: token},
+        }).select(readParticipantSelect).exec();
+        const currentParticipant = await this.participantModel.find({
+            poll: new Types.ObjectId(id),
+            token,
+        }).exec();
+        return [...participants, ...currentParticipant];
     }
 
     async postParticipation(id: string, dto: ParticipantDto): Promise<Participant> {

--- a/frontend/src/app/poll/choose-events/choose-events.component.ts
+++ b/frontend/src/app/poll/choose-events/choose-events.component.ts
@@ -68,7 +68,7 @@ export class ChooseEventsComponent implements OnInit {
           this.editChecks = new Array(this.pollEvents.length).fill(CheckboxState.FALSE);
           this.bookedEvents = new Array(this.pollEvents.length).fill(false);
         })),
-        this.pollService.getParticipants(id).pipe(tap(participants => this.participants = participants)),
+        this.pollService.getParticipants(id, this.token).pipe(tap(participants => this.participants = participants)),
       ])),
     ).subscribe(([poll, events, participants]) => {
       let description = '';

--- a/frontend/src/app/poll/services/poll.service.ts
+++ b/frontend/src/app/poll/services/poll.service.ts
@@ -1,4 +1,4 @@
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 
@@ -23,8 +23,14 @@ export class PollService {
     return this.http.get<PollEvent[]>(`${environment.backendURL}/poll/${id}/events`);
   }
 
-  getParticipants(id: string): Observable<Participant[]> {
-    return this.http.get<Participant[]>(`${environment.backendURL}/poll/${id}/participate`);
+  getParticipants(id: string, token: string): Observable<Participant[]> {
+    const options = {
+      headers: new HttpHeaders({
+        'Content-Type': 'application/json',
+        'Participant-Token': token,
+      }),
+    };
+    return this.http.get<Participant[]>(`${environment.backendURL}/poll/${id}/participate`, options);
   }
 
   isAdmin(id: string, adminToken: string) {


### PR DESCRIPTION
## Description
This PR addresses #64 by implementing a solution that allows users to edit or delete their participation in a poll. This is achieved by sending a Participant-Token header to the backend with the user's current token. With this new implementation, the backend no longer filters out the user's own token, thus enabling them to edit or delete their participation.