### PR TITLE
Shorter IDs

### DIFF
--- a/apps/backend/src/poll/poll/poll.controller.spec.ts
+++ b/apps/backend/src/poll/poll/poll.controller.spec.ts
@@ -34,7 +34,7 @@ describe('PollController', () => {
 
     it('should call getPoll', async () => {
       jest.spyOn(service, 'getPoll')
-      await controller.getPoll(PollStub()._id.toString());
+      await controller.getPoll(PollStub()._id);
       expect(service.getPoll).toHaveBeenCalled();
     });
 });

--- a/apps/backend/src/poll/poll/poll.controller.ts
+++ b/apps/backend/src/poll/poll/poll.controller.ts
@@ -9,14 +9,17 @@ import {
   ReadPollDto,
   ReadStatsPollDto,
 } from '@apollusia/types';
+import {ObjectIdPipe} from "@mean-stream/nestx";
 import {
   Body,
-  Controller, DefaultValuePipe,
+  Controller,
+  DefaultValuePipe,
   Delete,
   Get,
   Headers,
   NotFoundException,
-  Param, ParseBoolPipe,
+  Param,
+  ParseBoolPipe,
   Post,
   Put,
   Query,
@@ -24,6 +27,7 @@ import {
 import {Types} from 'mongoose';
 
 import {PollService} from './poll.service';
+
 
 @Controller('poll')
 export class PollController {
@@ -43,12 +47,12 @@ export class PollController {
     }
 
     @Get(':id/admin/:token')
-    async isAdmin(@Param('id') id: string, @Param('token') token: string): Promise<boolean> {
+    async isAdmin(@Param('id', ObjectIdPipe) id: Types.ObjectId, @Param('token') token: string): Promise<boolean> {
         return this.pollService.isAdmin(id, token);
     }
 
     @Get(':id')
-    async getPoll(@Param('id') id: string): Promise<ReadPollDto> {
+    async getPoll(@Param('id', ObjectIdPipe) id: Types.ObjectId): Promise<ReadPollDto> {
         return this.pollService.getPoll(id);
     }
 
@@ -58,12 +62,12 @@ export class PollController {
     }
 
     @Put(':id')
-    async putPoll(@Param('id') id: string, @Body() pollDto: PollDto): Promise<ReadPollDto> {
+    async putPoll(@Param('id', ObjectIdPipe) id: Types.ObjectId, @Body() pollDto: PollDto): Promise<ReadPollDto> {
         return this.pollService.putPoll(id, pollDto);
     }
 
     @Post(':id/clone')
-    async clonePoll(@Param('id') id: string): Promise<ReadPollDto> {
+    async clonePoll(@Param('id', ObjectIdPipe) id: Types.ObjectId): Promise<ReadPollDto> {
         const poll = await this.pollService.getPoll(id);
         if (!poll) {
             throw new NotFoundException(id);
@@ -73,7 +77,7 @@ export class PollController {
     }
 
     @Delete(':id')
-    async deletePoll(@Param('id') id: string): Promise<ReadPollDto | undefined> {
+    async deletePoll(@Param('id', ObjectIdPipe) id: Types.ObjectId): Promise<ReadPollDto | undefined> {
         const poll = await this.pollService.deletePoll(id);
         if (!poll) {
             throw new NotFoundException(id);
@@ -83,7 +87,7 @@ export class PollController {
     }
 
     @Get(':id/events')
-    async getEvents(@Param('id') id: string): Promise<PollEvent[]> {
+    async getEvents(@Param('id', ObjectIdPipe) id: Types.ObjectId): Promise<PollEvent[]> {
         const poll = await this.pollService.getPoll(id);
         if (!poll) {
             throw new NotFoundException(id);
@@ -93,7 +97,7 @@ export class PollController {
     }
 
     @Post(':id/events')
-    async postEvents(@Param('id') id: string, @Body() pollEvents: PollEventDto[]): Promise<PollEvent[]> {
+    async postEvents(@Param('id', ObjectIdPipe) id: Types.ObjectId, @Body() pollEvents: PollEventDto[]): Promise<PollEvent[]> {
         const poll = await this.pollService.getPoll(id);
         if (!poll) {
             throw new NotFoundException(id);
@@ -104,14 +108,14 @@ export class PollController {
 
     @Get(':id/participate')
     async getParticipants(
-        @Param('id') id: string,
+        @Param('id', ObjectIdPipe) id: Types.ObjectId,
         @Headers('Participant-Token') token: string,
     ): Promise<ReadParticipantDto[]> {
         return this.pollService.getParticipants(id, token);
     }
 
     @Post(':id/participate')
-    async postParticipation(@Param('id') id: string, @Body() participant: ParticipantDto): Promise<Participant> {
+    async postParticipation(@Param('id', ObjectIdPipe) id: Types.ObjectId, @Body() participant: ParticipantDto): Promise<Participant> {
         return this.pollService.postParticipation(id, participant);
     }
 
@@ -122,8 +126,8 @@ export class PollController {
 
     @Put(':id/participate/:participantId')
     async editParticipation(
-        @Param('id') id: string,
-        @Param('participantId') participantId: string,
+        @Param('id', ObjectIdPipe) id: Types.ObjectId,
+        @Param('participantId', ObjectIdPipe) participantId: Types.ObjectId,
         @Headers('Participant-Token') token: string,
         @Body() participant: ParticipantDto,
     ): Promise<ReadParticipantDto | null> {
@@ -132,14 +136,14 @@ export class PollController {
 
     @Delete(':id/participate/:participantId')
     async deleteParticipation(
-        @Param('id') id: string,
-        @Param('participantId') participantId: string,
+        @Param('id', ObjectIdPipe) id: Types.ObjectId,
+        @Param('participantId', ObjectIdPipe) participantId: Types.ObjectId,
     ): Promise<ReadParticipantDto | null> {
         return this.pollService.deleteParticipation(id, participantId);
     }
 
     @Post(':id/book')
-    async bookEvents(@Param('id') id: string, @Body() events: string[]): Promise<ReadPollDto> {
+    async bookEvents(@Param('id', ObjectIdPipe) id: Types.ObjectId, @Body() events: string[]): Promise<ReadPollDto> {
         const poll = await this.pollService.getPoll(id);
         if (!poll) {
             throw new NotFoundException(id);

--- a/apps/backend/src/poll/poll/poll.service.spec.ts
+++ b/apps/backend/src/poll/poll/poll.service.spec.ts
@@ -38,7 +38,7 @@ describe('PollService', () => {
     });
 
     it('should get poll', async () => {
-        const poll = await service.getPoll(PollStub()._id.toString());
+        const poll = await service.getPoll(PollStub()._id);
         expect(poll).toBeDefined();
     });
 
@@ -53,7 +53,7 @@ describe('PollService', () => {
         modifiedPoll.title = 'Party';
 
         const oldPoll = await pollModel.findOne({_id: PollStub()._id}).exec();
-        await service.putPoll(modifiedPoll._id.toString(), modifiedPoll);
+        await service.putPoll(modifiedPoll._id, modifiedPoll);
         const updatedPoll = await pollModel.findOne({_id: PollStub()._id}).exec();
 
         expect(oldPoll._id).toEqual(updatedPoll._id);
@@ -67,7 +67,7 @@ describe('PollService', () => {
         modifiedPoll.title = 'Meeting';
 
         const oldPoll = await pollModel.findOne({_id: PollStub()._id}).exec();
-        await expect(service.putPoll(modifiedPoll._id.toString(), modifiedPoll)).rejects.toThrow(NotFoundException);
+        await expect(service.putPoll(modifiedPoll._id, modifiedPoll)).rejects.toThrow(NotFoundException);
         const updatedPoll = await pollModel.findOne({_id: PollStub()._id}).exec();
         const pollCounts = await pollModel.countDocuments().exec();
 
@@ -80,7 +80,7 @@ describe('PollService', () => {
         let pollCounts = await pollModel.countDocuments().exec();
         expect(pollCounts).toEqual(1);
 
-        const clonedPoll = await service.clonePoll(PollStub()._id.toString());
+        const clonedPoll = await service.clonePoll(PollStub()._id);
         pollCounts = await pollModel.countDocuments().exec();
 
         expect(clonedPoll).toBeDefined();
@@ -92,7 +92,7 @@ describe('PollService', () => {
         let pollCounts = await pollModel.countDocuments().exec();
         expect(pollCounts).toEqual(2);
 
-        await service.deletePoll(PollStub()._id.toString());
+        await service.deletePoll(PollStub()._id);
         pollCounts = await pollModel.countDocuments().exec();
 
         expect(pollCounts).toEqual(1);
@@ -102,7 +102,7 @@ describe('PollService', () => {
         let pollCounts = await pollModel.countDocuments().exec();
         expect(pollCounts).toEqual(1);
 
-        await expect(service.deletePoll(PollStub()._id.toString())).rejects.toThrow(NotFoundException);
+        await expect(service.deletePoll(PollStub()._id)).rejects.toThrow(NotFoundException);
         pollCounts = await pollModel.countDocuments().exec();
 
         expect(pollCounts).toEqual(1);
@@ -112,7 +112,7 @@ describe('PollService', () => {
         const poll = await pollModel.findOne({title: 'Party (clone)'}).exec();
         let pollEventCount = await pollEventModel.countDocuments().exec();
         expect(pollEventCount).toEqual(0);
-        const event = await service.postEvents(poll._id.toString(), [PollEventStub()] as any);
+        const event = await service.postEvents(poll._id, [PollEventStub()] as any);
 
         pollEventCount = await pollEventModel.countDocuments().exec();
         expect(event[0].poll).toEqual(poll._id);
@@ -121,39 +121,39 @@ describe('PollService', () => {
 
     it('should get events from poll', async () => {
         const poll = await pollModel.findOne({title: 'Party (clone)'}).exec();
-        const events = await service.getEvents(poll._id.toString());
+        const events = await service.getEvents(poll._id);
         expect(events.length).toEqual(1);
     });
 
     it('should delete events from poll', async () => {
         const poll = await pollModel.findOne({title: 'Party (clone)'}).exec();
-        const events = await service.postEvents(poll._id.toString(), []);
+        const events = await service.postEvents(poll._id, []);
         expect(events.length).toEqual(0);
     });
 
     it('should not get participants from poll', async () => {
        const poll = await pollModel.findOne({title: 'Party (clone)'}).exec();
-       const participants = await service.getParticipants(poll._id.toString(), ParticipantStub().token);
+       const participants = await service.getParticipants(poll._id, ParticipantStub().token);
        expect(participants.length).toEqual(0);
     });
 
     it('should post participation', async () => {
       const poll = await pollModel.findOne({title: 'Party (clone)'}).exec();
-      await service.postParticipation(poll._id.toString(), ParticipantStub());
-      const participants = await service.getParticipants(poll._id.toString(), ParticipantStub().token);
+      await service.postParticipation(poll._id, ParticipantStub());
+      const participants = await service.getParticipants(poll._id, ParticipantStub().token);
       expect(participants.length).toEqual(1);
     });
 
     it('should not post participation', async () => {
       await expect(service.postParticipation(
-        new Types.ObjectId('5f1f9b9b9b9b942b9b9b9b9b').toString(),
+        new Types.ObjectId('5f1f9b9b9b9b942b9b9b9b9b'),
         ParticipantStub())
       ).rejects.toThrow(NotFoundException);
     });
 
     it('should be admin', async () => {
       const poll = await pollModel.findOne({title: 'Party (clone)'}).exec();
-      const isAdmin = await service.isAdmin(poll._id.toString(), ParticipantStub().token);
+      const isAdmin = await service.isAdmin(poll._id, ParticipantStub().token);
       expect(isAdmin).toEqual(true);
     });
 

--- a/apps/backend/test/stubs/PollStub.ts
+++ b/apps/backend/test/stubs/PollStub.ts
@@ -2,8 +2,10 @@ import {Poll} from '@apollusia/types';
 import {Types} from 'mongoose';
 
 export const PollStub = (): Poll => {
+  const _id = new Types.ObjectId('5f1f9b9b9b9b9b9b9b9b9b9b');
   return {
-    _id: new Types.ObjectId('5f1f9b9b9b9b9b9b9b9b9b9b'),
+    _id,
+    id: _id.toString('base64'),
     title: 'Test',
     settings: {
       allowMaybe: true,

--- a/apps/frontend/src/app/dashboard/card/card.component.html
+++ b/apps/frontend/src/app/dashboard/card/card.component.html
@@ -3,11 +3,11 @@
     <div class="d-flex justify-content-between">
       <h5 class="card-title">{{poll.title}}</h5>
       <div class="d-flex">
-        <a class="btn btn-flash-border-primary bi-person" [routerLink]="['/poll', poll._id, 'participate']">
+        <a class="btn btn-flash-border-primary bi-person" [routerLink]="['/poll', poll.id, 'participate']">
           View
         </a>
         <a *ngIf="admin" class="btn btn-flash-border-primary bi-pencil-square"
-           [routerLink]="['/poll', poll._id]">
+           [routerLink]="['/poll', poll.id]">
           Edit
         </a>
       </div>

--- a/apps/frontend/src/app/poll/create-poll/create-edit-poll.component.ts
+++ b/apps/frontend/src/app/poll/create-poll/create-edit-poll.component.ts
@@ -183,7 +183,7 @@ export class CreateEditPollComponent implements OnInit {
 
   private postPoll(poll: CreatePollDto) {
     this.http.post<Poll>(`${environment.backendURL}/poll`, poll).subscribe((res: Poll) => {
-      this.router.navigate([`poll/${res._id}/date`]).then();
+      this.router.navigate([`poll/${res.id}/date`]).then();
     });
   }
 

--- a/libs/types/src/lib/dto/poll.dto.ts
+++ b/libs/types/src/lib/dto/poll.dto.ts
@@ -1,7 +1,7 @@
 import {ApiProperty, OmitType} from '@nestjs/swagger';
 import {Poll} from '../schema';
 
-export class PollDto extends OmitType(Poll, ['_id'] as const) {
+export class PollDto extends OmitType(Poll, ['id', '_id'] as const) {
 }
 
 export const readPollExcluded = ['adminToken', 'adminMail', 'adminPush'] as const;

--- a/libs/types/src/lib/schema/poll.schema.ts
+++ b/libs/types/src/lib/schema/poll.schema.ts
@@ -6,10 +6,25 @@ import {IsNotEmpty, IsObject, IsOptional, IsString, MinLength, ValidateNested} f
 import {Types} from 'mongoose';
 import {Settings} from './settings';
 
-@Schema({timestamps: true})
+@Schema({
+  timestamps: true,
+  id: false,
+  toJSON: {virtuals: true},
+  toObject: {virtuals: true},
+  virtuals: {
+    id: {
+      get: function (this: Poll) {
+        return this._id.toString('base64');
+      },
+    },
+  },
+})
 export class Poll {
     @ApiProperty()
     _id: Types.ObjectId;
+
+    @ApiProperty()
+    id: string;
 
     @Prop({required: true})
     @ApiProperty()

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@angular/pwa": "^15.2.8",
     "@angular/router": "~15.2.9",
     "@angular/service-worker": "^15.2.9",
-    "@mean-stream/nestx": "^0.6.1",
+    "@mean-stream/nestx": "^0.7.0",
     "@mean-stream/ngbx": "^0.9.0",
     "@nestjs-modules/mailer": "^1.8.1",
     "@nestjs/common": "^9.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ dependencies:
     specifier: ^15.2.9
     version: 15.2.9(@angular/common@15.2.9)(@angular/core@15.2.9)
   '@mean-stream/nestx':
-    specifier: ^0.6.1
-    version: 0.6.1(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/mongoose@9.2.2)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(mongoose@7.1.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)(tslib@2.5.0)
+    specifier: ^0.7.0
+    version: 0.7.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/mongoose@9.2.2)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(mongoose@7.1.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)(tslib@2.5.0)
   '@mean-stream/ngbx':
     specifier: ^0.9.0
     version: 0.9.0(@angular/common@15.2.9)(@angular/core@15.2.9)(@angular/forms@15.2.9)(@angular/router@15.2.9)(@ng-bootstrap/ng-bootstrap@14.1.1)(bootstrap@5.2.3)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
@@ -4645,8 +4645,8 @@ packages:
     resolution: {integrity: sha512-YbrUWREPGEjE/FU6foXcAT1YbVwqD/jkYnY1dFb0o4AxtP3s4xKBthlELjndZih8uwsDWgQZx1eNskRNe2BgZQ==}
     dev: false
 
-  /@mean-stream/nestx@0.6.1(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/mongoose@9.2.2)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(mongoose@7.1.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)(tslib@2.5.0):
-    resolution: {integrity: sha512-POH2LBEmhebG3CedtHyNRMpBELXImz1Gukgdxv/pMspgNUg5DMd/0qc4Gk22cgh15Yv3wqmA6kfOgt3tGwlG8Q==}
+  /@mean-stream/nestx@0.7.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/mongoose@9.2.2)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(mongoose@7.1.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)(tslib@2.5.0):
+    resolution: {integrity: sha512-vmmgPeTP6rDhJnJPUwQSoCbpYIT3HbrcHu/dHrDKO+fAGckjegB0cz66hiIzO9jlYm5oyaGE0MlUL/Dk2bE82w==}
     peerDependencies:
       '@nestjs/common': ^9.0.0
       '@nestjs/core': ^9.0.0


### PR DESCRIPTION
Shortened IDs using base64 instead of base16. For example:
> https://apollusia.uniks.de/poll/645ca44113a3287b2fa39705/participate

Shortens to:

> https://apollusia.uniks.de/poll/ZFykQROjKHsvo5cF/participate

The basic implementation is merely present in CardComponent, which links using `id` instead of `_id`, and the `PollSchema`, which adds the virtual `id` property. The rest is some general refactoring; changing id parameters to use type ObjectId instead of string.