### PR TITLE
Show participation timestamps

### DIFF
--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.html
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.html
@@ -75,12 +75,12 @@
         <ng-container *ngIf="showResults">
           <tr *ngFor="let participant of participants">
             <th>
-              <div *ngIf="poll?.settings?.anonymous">
-                Anonymous
-              </div>
-              <div *ngIf="!poll?.settings?.anonymous">
-                {{participant.name}}
-              </div>
+              {{ poll?.settings?.anonymous ? 'Anonymous' : participant.name }}
+              <span *ngIf="participant.createdAt" class="small text-muted" [ngbTooltip]="participant.createdAt | date:'medium'">
+                {{ participant.createdAt | date: 'shortTime' }}
+              </span>
+              <i *ngIf="participant.updatedAt !== participant.createdAt" class="small text-muted bi-pencil-square" [ngbTooltip]="'edited ' + (participant.updatedAt | date:'medium')">
+              </i>
             </th>
             <ng-container *ngIf="participant !== editParticipant">
               <td *ngFor="let pollEvent of pollEvents; let n=index">

--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.html
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.html
@@ -79,8 +79,9 @@
               <span *ngIf="participant.createdAt" class="small text-muted" [ngbTooltip]="participant.createdAt | date:'medium'">
                 {{ participant.createdAt | date: 'shortTime' }}
               </span>
-              <i *ngIf="participant.updatedAt !== participant.createdAt" class="small text-muted bi-pencil-square" [ngbTooltip]="'edited ' + (participant.updatedAt | date:'medium')">
-              </i>
+              <span *ngIf="participant.updatedAt !== participant.createdAt" class="small text-muted" [ngbTooltip]="participant.updatedAt | date:'medium'">
+                &bull; edited
+              </span>
             </th>
             <ng-container *ngIf="participant !== editParticipant">
               <td *ngFor="let pollEvent of pollEvents; let n=index">

--- a/libs/types/src/lib/schema/participant.schema.ts
+++ b/libs/types/src/lib/schema/participant.schema.ts
@@ -7,10 +7,16 @@ import {Types} from 'mongoose';
 import {PollEvent} from './poll-event.schema';
 import {Poll} from './poll.schema';
 
-@Schema()
+@Schema({timestamps: true})
 export class Participant {
     @ApiProperty()
     _id: Types.ObjectId;
+
+    @ApiProperty()
+    createdAt?: Date;
+
+    @ApiProperty()
+    updatedAt?: Date;
 
     @Ref(Poll.name)
     poll: Types.ObjectId;

--- a/libs/types/src/lib/schema/participant.schema.ts
+++ b/libs/types/src/lib/schema/participant.schema.ts
@@ -1,6 +1,6 @@
 import {Ref, RefArray} from '@mean-stream/nestx';
 import {Prop, Schema, SchemaFactory} from '@nestjs/mongoose';
-import {ApiProperty} from '@nestjs/swagger';
+import {ApiProperty, ApiPropertyOptional} from '@nestjs/swagger';
 import {IsEmail, IsNotEmpty, IsOptional, IsString, MinLength} from 'class-validator';
 import {Types} from 'mongoose';
 
@@ -12,10 +12,10 @@ export class Participant {
     @ApiProperty()
     _id: Types.ObjectId;
 
-    @ApiProperty()
+    @ApiPropertyOptional()
     createdAt?: Date;
 
-    @ApiProperty()
+    @ApiPropertyOptional()
     updatedAt?: Date;
 
     @Ref(Poll.name)


### PR DESCRIPTION
New Participations will track the created and updated time and show that in the participant table next to the name. When old participations are edited, only the updated timestamp will be shown. The detailed date and time are visible on hover. The creation timestamp makes it easier to see which participation came last, for example when a participant submits twice.

## Screenshots

<img width="213" alt="Screenshot 2023-05-14 at 11 10 59" src="https://github.com/Morphclue/apollusia/assets/4145923/7f51e4ba-809d-4b43-b5f7-fdabe06c84b2">

<img width="221" alt="Screenshot 2023-05-14 at 11 13 04" src="https://github.com/Morphclue/apollusia/assets/4145923/d984e239-1d15-4afe-9557-949f0296a974">
