### PR TITLE
Fix blockquote styling

### DIFF
--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -119,6 +119,10 @@ $danger: $mauve;
   margin: 0;
 }
 
+.markdown p {
+  margin: 0 0;
+}
+
 .bi-zoom::before {
   // the 'bi-' prefix gives us all the styling from bootstrap-icons.
   // this class needs to be used with another icon like .bi-camera-video,

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -109,18 +109,19 @@ $danger: $mauve;
   color: white;
 }
 
-.markdown img {
-  max-width: 100%;
-}
+.markdown {
+  img {
+    max-width: 100%;
+  }
 
-.markdown blockquote {
-  border-left: 4px solid $info;
-  padding: 0 1rem;
-  margin: 0;
-}
+  blockquote {
+    border-left: 4px solid $info;
+    padding: 0 1rem;
+  }
 
-.markdown p {
-  margin: 0;
+  p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .bi-zoom::before {

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -120,7 +120,7 @@ $danger: $mauve;
 }
 
 .markdown p {
-  margin: 0 0;
+  margin: 0;
 }
 
 .bi-zoom::before {

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -113,6 +113,12 @@ $danger: $mauve;
   max-width: 100%;
 }
 
+.markdown blockquote {
+  border-left: 4px solid $info;
+  padding: 0 1rem;
+  margin: 0;
+}
+
 .bi-zoom::before {
   // the 'bi-' prefix gives us all the styling from bootstrap-icons.
   // this class needs to be used with another icon like .bi-camera-video,


### PR DESCRIPTION
# Context
I've noticed that blockquotes don't seem to work, even tho they are specified in the [commonmark help page](https://commonmark.org/help/). After further analyzing the code I've noticed that the html is correctly rendering `<blockquote>`-tags, but there seems to be no proper styling. Therefore I've added a style for blockquotes in the Apollusia color scheme:
![image](https://github.com/Morphclue/apollusia/assets/43741877/5a425eaa-51eb-48d8-9dc7-9990dfe0611d)

As you can see this looks pretty off, because of all the weird margin between components.
This is the final style (with fixed margins for `<p>`-tags):
![image](https://github.com/Morphclue/apollusia/assets/43741877/8a485713-f2f1-4706-b06e-9859257ba5f6)

