### PR TITLE
Grey out / disable previous slots

### DIFF
--- a/apps/frontend/src/app/poll/choose-date/choose-date.component.html
+++ b/apps/frontend/src/app/poll/choose-date/choose-date.component.html
@@ -22,7 +22,6 @@
       <div
         #segmentElement
         class="cal-hour-segment"
-        [class.disabled-pointer-events]="disabledHour"
         [style.height.px]="segmentHeight"
         [class.cal-hour-start]="segment.isStart"
         [class.cal-after-hour-start]="!segment.isStart"

--- a/apps/frontend/src/app/poll/choose-date/choose-date.component.html
+++ b/apps/frontend/src/app/poll/choose-date/choose-date.component.html
@@ -18,19 +18,22 @@
     let-segmentHeight="segmentHeight"
     let-isTimeLabel="isTimeLabel"
   >
-    <div
-      #segmentElement
-      class="cal-hour-segment"
-      [style.height.px]="segmentHeight"
-      [class.cal-hour-start]="segment.isStart"
-      [class.cal-after-hour-start]="!segment.isStart"
-      (mousedown)="startDragToCreate(segment, $event, segmentElement)"
-    >
-      @if (isTimeLabel) {
-        <div class="cal-time">
-          {{ segment.date | calendarDate:'weekViewHour':locale }}
-        </div>
-      }
+    <div [class.disabled-hour]="isDisabledHour(segment.date)">
+      <div
+        #segmentElement
+        class="cal-hour-segment"
+        [class.disabled-pointer-events]="disabledHour"
+        [style.height.px]="segmentHeight"
+        [class.cal-hour-start]="segment.isStart"
+        [class.cal-after-hour-start]="!segment.isStart"
+        (mousedown)="startDragToCreate(segment, $event, segmentElement)"
+      >
+        @if (isTimeLabel) {
+          <div class="cal-time">
+            {{ segment.date | calendarDate:'weekViewHour':locale }}
+          </div>
+        }
+      </div>
     </div>
   </ng-template>
   <div class="scroll-container border border-primary shadow mb-3">

--- a/apps/frontend/src/app/poll/choose-date/choose-date.component.html
+++ b/apps/frontend/src/app/poll/choose-date/choose-date.component.html
@@ -18,7 +18,7 @@
     let-segmentHeight="segmentHeight"
     let-isTimeLabel="isTimeLabel"
   >
-    <div [class.disabled-hour]="isDisabledHour(segment.date)">
+    <div [class.disabled-hour]="segment.date < disabledBefore">
       <div
         #segmentElement
         class="cal-hour-segment"

--- a/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
+++ b/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
@@ -4,9 +4,9 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {CalendarEvent, CalendarEventTimesChangedEvent} from 'angular-calendar';
 import {WeekViewHourSegment} from 'calendar-utils';
-import {addMinutes, differenceInMinutes, endOfWeek, format, getMinutes, isBefore, setMinutes} from 'date-fns';
-import {fromEvent, Observable} from 'rxjs';
-import {finalize, map, takeUntil} from 'rxjs/operators';
+import {addMinutes, differenceInMinutes, endOfWeek, format} from 'date-fns';
+import {fromEvent} from 'rxjs';
+import {finalize, takeUntil} from 'rxjs/operators';
 
 import {environment} from '../../../environments/environment';
 import {CreatePollEventDto} from '../../model';
@@ -16,15 +16,16 @@ import {ChooseDateService} from '../services/choose-date.service';
   selector: 'app-choose-date',
   templateUrl: './choose-date.component.html',
   styleUrls: ['./choose-date.component.scss'],
+  providers: [ChooseDateService],
 })
 export class ChooseDateComponent implements AfterViewInit {
   viewDate = new Date();
   dragToCreateActive = true;
-  weekStartsOn: 1 = 1 as const;
+  weekStartsOn = 1 as const;
   previousEventDuration = 15;
-  id: string = '';
-  note: string = '';
-  noteEvent?: CalendarEvent = undefined;
+  id = '';
+  note = '';
+  noteEvent?: CalendarEvent;
   disabledBefore = Date.now() - 15 * 60 * 1000;
 
   constructor(
@@ -37,8 +38,7 @@ export class ChooseDateComponent implements AfterViewInit {
     private activatedRoute: ActivatedRoute,
     private elementRef: ElementRef,
   ) {
-    const routeId: Observable<string> = route.params.pipe(map(({id}) => id));
-    routeId.subscribe((id: string) => {
+    route.params.subscribe(({id}) => {
       this.id = id;
       this.chooseDateService.updateEvents(id);
     });

--- a/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
+++ b/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
@@ -25,7 +25,6 @@ export class ChooseDateComponent implements AfterViewInit {
   id: string = '';
   note: string = '';
   noteEvent?: CalendarEvent = undefined;
-  disabledHour: boolean;
 
   constructor(
     private modalService: NgbModal,
@@ -163,8 +162,7 @@ export class ChooseDateComponent implements AfterViewInit {
   isDisabledHour(date: Date) {
     const now = new Date();
     const lastQuarter = Math.floor(getMinutes(now) / 15) * 15 - 15;
-    this.disabledHour = isBefore(date, setMinutes(now, lastQuarter));
-    return this.disabledHour;
+    return isBefore(date, setMinutes(now, lastQuarter));
   }
 
   private updateTime(event: CalendarEvent) {

--- a/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
+++ b/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
@@ -25,6 +25,7 @@ export class ChooseDateComponent implements AfterViewInit {
   id: string = '';
   note: string = '';
   noteEvent?: CalendarEvent = undefined;
+  disabledBefore = Date.now() - 15 * 60 * 1000;
 
   constructor(
     private modalService: NgbModal,
@@ -157,12 +158,6 @@ export class ChooseDateComponent implements AfterViewInit {
   autofill(event: CalendarEvent) {
     this.chooseDateService.autofillEvent = event;
     this.router.navigate(['autofill'], {relativeTo: this.activatedRoute}).then();
-  }
-
-  isDisabledHour(date: Date) {
-    const now = new Date();
-    const lastQuarter = Math.floor(getMinutes(now) / 15) * 15 - 15;
-    return isBefore(date, setMinutes(now, lastQuarter));
   }
 
   private updateTime(event: CalendarEvent) {

--- a/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
+++ b/apps/frontend/src/app/poll/choose-date/choose-date.component.ts
@@ -4,7 +4,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {CalendarEvent, CalendarEventTimesChangedEvent} from 'angular-calendar';
 import {WeekViewHourSegment} from 'calendar-utils';
-import {addMinutes, differenceInMinutes, endOfWeek, format} from 'date-fns';
+import {addMinutes, differenceInMinutes, endOfWeek, format, getMinutes, isBefore, setMinutes} from 'date-fns';
 import {fromEvent, Observable} from 'rxjs';
 import {finalize, map, takeUntil} from 'rxjs/operators';
 
@@ -25,6 +25,7 @@ export class ChooseDateComponent implements AfterViewInit {
   id: string = '';
   note: string = '';
   noteEvent?: CalendarEvent = undefined;
+  disabledHour: boolean;
 
   constructor(
     private modalService: NgbModal,
@@ -157,6 +158,13 @@ export class ChooseDateComponent implements AfterViewInit {
   autofill(event: CalendarEvent) {
     this.chooseDateService.autofillEvent = event;
     this.router.navigate(['autofill'], {relativeTo: this.activatedRoute}).then();
+  }
+
+  isDisabledHour(date: Date) {
+    const now = new Date();
+    const lastQuarter = Math.floor(getMinutes(now) / 15) * 15 - 15;
+    this.disabledHour = isBefore(date, setMinutes(now, lastQuarter));
+    return this.disabledHour;
   }
 
   private updateTime(event: CalendarEvent) {

--- a/apps/frontend/src/app/poll/services/choose-date.service.ts
+++ b/apps/frontend/src/app/poll/services/choose-date.service.ts
@@ -7,12 +7,10 @@ import {addDays, addMinutes, format} from 'date-fns';
 import {environment} from '../../../environments/environment';
 import {PollEvent} from '../../model';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class ChooseDateService {
   events: CalendarEvent[] = [];
-  autofillEvent?: CalendarEvent = undefined;
+  autofillEvent?: CalendarEvent;
 
   constructor(private http: HttpClient) {
   }

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -109,6 +109,15 @@ $danger: $mauve;
   color: white;
 }
 
+.disabled-hour {
+  background-color: lightgrey;
+  cursor: not-allowed;
+}
+
+.disabled-hour > .disabled-pointer-events {
+  pointer-events: none;
+}
+
 .markdown {
   img {
     max-width: 100%;

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -114,7 +114,7 @@ $danger: $mauve;
   cursor: not-allowed;
 }
 
-.disabled-hour > .disabled-pointer-events {
+.disabled-hour > .cal-hour-segment {
   pointer-events: none;
 }
 


### PR DESCRIPTION
# Context
Previous events can't be created anymore with the frontend.
There will still probably be easy workarounds to bypass this feature, but that shouldn't be an issue.

## Alternatives
Include an expert setting to allow previous events. There may be reasons why someone wants to allow the creation of events in the past. 