### PR TITLE
Prevent validation error in Anonymous polls

### DIFF
--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.html
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.html
@@ -64,21 +64,14 @@
           @if (!closedReason) {
             <tr>
               <th style="min-width: 240px" scope="row">
-                @if (!poll?.settings?.anonymous) {
-                  <input
-                    class="form-control"
-                    type="text"
-                    id="name"
-                    placeholder="Your name"
-                    [(ngModel)]="newParticipant.name" (change)="validateNew()">
-                }
-                @if (poll?.settings?.anonymous) {
-                  <input
-                    class="form-control"
-                    type="text"
-                    value="Anonymous"
-                    [disabled]="true">
-                }
+                <input
+                  class="form-control"
+                  type="text"
+                  id="name"
+                  placeholder="Your name"
+                  [disabled]="poll?.settings?.anonymous ?? false"
+                  [(ngModel)]="newParticipant.name" (change)="validateNew()"
+                >
               </th>
               @for (event of pollEvents; track event) {
                 <td>

--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.ts
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.ts
@@ -71,9 +71,6 @@ export class ChooseEventsComponent implements OnInit {
         this.pollService.getEvents(id).pipe(tap(events => {
           this.pollEvents = events;
           this.bookedEvents = new Array(this.pollEvents.length).fill(false);
-          for (const event of events) {
-            this.newParticipant.selection[event._id] ||= 'no';
-          }
           this.validateNew();
         })),
         this.pollService.getParticipants(id).pipe(tap(participants => this.participants = participants)),
@@ -82,6 +79,7 @@ export class ChooseEventsComponent implements OnInit {
     ).subscribe(([poll, events, participants, isAdmin]) => {
       this.setDescription(poll, events, participants);
 
+      this.clearSelection();
       this.bookedEvents = events.map(e => poll.bookedEvents.includes(e._id));
       this.isAdmin = isAdmin;
       this.updateHelpers();
@@ -211,7 +209,7 @@ export class ChooseEventsComponent implements OnInit {
   }
 
   private clearSelection(){
-    this.newParticipant.name = '';
+    this.newParticipant.name = this.poll?.settings?.anonymous ? 'Anonymous' : '';
     for (const event of this.pollEvents) {
       this.newParticipant.selection[event._id] = 'no';
     }


### PR DESCRIPTION
Currently, it is not possible to participate in anonymous polls, as the participant name must not be empty.
The fix is that the name "Anonymous" will always be used.