### PR TITLE
Fix ETXTBSY spawn 

### DIFF
--- a/apps/backend/src/utils/mongo-util.ts
+++ b/apps/backend/src/utils/mongo-util.ts
@@ -1,5 +1,6 @@
 import {MongooseModule, MongooseModuleOptions} from '@nestjs/mongoose';
 import {MongoMemoryServer} from 'mongodb-memory-server';
+import {disconnect} from 'mongoose';
 
 let mongoMemoryServer: MongoMemoryServer;
 
@@ -15,6 +16,7 @@ export const rootMongooseTestModule = (options: MongooseModuleOptions = {}) => M
 });
 
 export const closeMongoConnection = async () => {
+  await disconnect();
   if (mongoMemoryServer) {
     await mongoMemoryServer.stop();
   }


### PR DESCRIPTION
# Context
Currently nearly every second run fails, because of this the ETXTBSY error mentioned in #106. This is pretty annoying. I'm unsure how to fix this, but I'll leave this branch open to improve some behaviour and test it out step by step.

Since version 7 of the mongodb-memory-server a `disconnect()` is advised.