### PR TITLE
CI: Automatically fix and commit problems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
-        run: pnpm run lint:${{ matrix.app }}
+        run: pnpm run lint:${{ matrix.app }} --fix
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: Fix lint problems'
       - name: Test
         run: pnpm run test:${{ matrix.app }}


### PR DESCRIPTION
The lint step now uses `--fix` to resolve simple problems (e.g. the recently added #138).
Any changes are automatically committed and pushed.

Note:
- Remaining errors will still count as a job failure.
- The new commit will not trigger CI (this is a GitHub limitation/safety measure to avoid cyclic CI runs).