### PR TITLE
Add Share via Email Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ All features are completely free and can be used without registration.
   <dd>Keep track of your polled events and 1-1 meetings using your favorite calendar app</dd>
 </dl>
 
+### Poll Management
+
+<dl>
+  <img src="docs/bootstrap-icons/icons/send.svg" alt="send" align="right" height="50">
+  <dt>Invite Participants</dt>
+  <dd>Invite participants via email or other means</dd>
+</dl>
+
 
 <!-- features:end -->
 

--- a/apps/frontend/src/app/about/features/features.json
+++ b/apps/frontend/src/app/about/features/features.json
@@ -151,7 +151,7 @@
       "title": "Invite Participants",
       "description": "Invite participants via email or other means",
       "support": {
-        "Apollusia": "Simple link sharing is possible",
+        "Apollusia": true,
         "Doodle": true,
         "DuD-Poll": true
       }

--- a/apps/frontend/src/app/core/info-table/info-table.component.html
+++ b/apps/frontend/src/app/core/info-table/info-table.component.html
@@ -38,6 +38,8 @@
       &nbsp;
       <button class="btn p-0 btn-link bi-clipboard" ngbTooltip="Copy to clipboard"
               (click)="copyToClipboard()"></button>
+      <button class="btn p-0 btn-link bi-envelope-at" ngbTooltip="Share via email"
+              (click)="draftEmail()"></button>
     </td>
   </tr>
   @if (stats) {

--- a/apps/frontend/src/app/core/info-table/info-table.component.ts
+++ b/apps/frontend/src/app/core/info-table/info-table.component.ts
@@ -31,4 +31,19 @@ export class InfoTableComponent implements OnInit {
       this.toastService.error('Copy Poll Link', 'Failed to copy link to clipboard', e);
     });
   }
+
+  draftEmail() {
+    const subject = `Poll Invitation: ${this.poll!.title}`;
+    const body = `Hello,
+
+I would like to invite you to participate in a poll.
+Please click the link below to participate.
+
+${this.url}
+
+Thank you!`;
+
+    const mailto = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    open(mailto, '_self');
+  }
 }


### PR DESCRIPTION
## New Features

+ Added a simple "Share via Email" button to the dashboard and polls.

![image](https://github.com/Morphclue/apollusia/assets/4145923/e0362df7-6f4f-4d77-8979-e0df7313172a)

The button opens the default mail application via a `mailto:` link, allowing the user to choose their own sender address and edit the text.

![image](https://github.com/Morphclue/apollusia/assets/4145923/5bf18ee5-f362-4b36-99a1-5105cec97136)

When redesigning the settings page, I will add an option to customize the email template.