### PR TITLE
Fix missing event population

### DIFF
--- a/apps/backend/src/poll/poll/poll.service.ts
+++ b/apps/backend/src/poll/poll/poll.service.ts
@@ -159,6 +159,7 @@ export class PollService implements OnModuleInit {
       .findById(id)
       .select(readPollSelect)
       .populate<{participants: number}>('participants')
+      .populate<{events: number}>('events')
       .exec();
   }
 


### PR DESCRIPTION
# Context
I've noticed that an undefined Options, when sending a link to someone on Discord.
> ✅ undefined Options - 👤 3 Participants

This was due to the missing population of events in the `get(id)`.