### PR TITLE
Show results after deadline

### DIFF
--- a/apps/backend/src/poll/poll/poll.service.ts
+++ b/apps/backend/src/poll/poll/poll.service.ts
@@ -258,8 +258,7 @@ export class PollService implements OnModuleInit {
       token,
     }).exec();
 
-    if (poll.adminToken === token || poll.settings.showResult === ShowResultOptions.IMMEDIATELY ||
-      poll.settings.showResult === ShowResultOptions.AFTER_PARTICIPATING && currentParticipant.length > 0) {
+    if (this.canViewResults(poll, token, currentParticipant.length > 0)) {
       const participants = await this.participantModel.find({
         poll: new Types.ObjectId(id),
         token: {$ne: token},
@@ -268,6 +267,22 @@ export class PollService implements OnModuleInit {
     }
 
     return currentParticipant;
+  }
+
+  private canViewResults(poll: Poll, token: string, currentParticipant: boolean) {
+    if (poll.adminToken === token) {
+      return true;
+    }
+    switch (poll.settings.showResult) {
+      case ShowResultOptions.IMMEDIATELY:
+        return true;
+      case ShowResultOptions.AFTER_PARTICIPATING:
+        return currentParticipant;
+      case ShowResultOptions.AFTER_DEADLINE:
+        return !poll.settings.deadline || +poll.settings.deadline < Date.now();
+      case ShowResultOptions.NEVER:
+        return false;
+    }
   }
 
   async findAllParticipants(poll: Types.ObjectId): Promise<Participant[]> {

--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.ts
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.ts
@@ -189,6 +189,15 @@ export class ChooseEventsComponent implements OnInit {
       case ShowResultOptions.AFTER_PARTICIPATING:
         this.hiddenReason = this.isAdmin || this.userVoted() ? undefined : 'This is a blind poll. You can\'t see results or other user\'s votes until you participate yourself.';
         break;
+      case ShowResultOptions.AFTER_DEADLINE: {
+        const deadline = this.poll.settings.deadline;
+        if (this.isAdmin || !deadline || new Date(deadline) < new Date()) {
+          this.hiddenReason = undefined;
+        } else {
+          this.hiddenReason = 'The results of this poll are hidden until the deadline is over. You can only see your own votes.';
+        }
+        break;
+      }
       default:
         this.hiddenReason = undefined;
     }

--- a/apps/frontend/src/app/poll/create-poll/create-edit-poll.component.html
+++ b/apps/frontend/src/app/poll/create-poll/create-edit-poll.component.html
@@ -159,7 +159,7 @@
               </label>
               <input class="form-check-input" type="checkbox" id="anonymous" formControlName="anonymous">
             </div>
-            <div class="form-group form-check" formGroupName="showResultGroup">
+            <div class="mt-3" formGroupName="showResultGroup">
               <label>Show results to participants</label>
               <div class="form-check">
                 <input class="form-check-input"

--- a/apps/frontend/src/app/poll/create-poll/create-edit-poll.component.html
+++ b/apps/frontend/src/app/poll/create-poll/create-edit-poll.component.html
@@ -186,6 +186,17 @@
               </div>
               <div class="form-check">
                 <input class="form-check-input"
+                       type="radio" id="showAfterDeadline"
+                       [value]="ShowResultOptions.AFTER_DEADLINE"
+                       formControlName="showResult">
+                <label class="form-check-label" for="showAfterDeadline">
+                  After deadline
+                  <i class="bi-question-circle text-muted" placement="top"
+                     ngbTooltip="Show results to participants after the deadline is over."></i>
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input"
                        type="radio"
                        id="showNever"
                        [value]="ShowResultOptions.NEVER"

--- a/libs/types/src/lib/schema/show-result-options.ts
+++ b/libs/types/src/lib/schema/show-result-options.ts
@@ -1,5 +1,6 @@
 export enum ShowResultOptions {
     IMMEDIATELY = 'immediately',
     AFTER_PARTICIPATING = 'after_participating',
+    AFTER_DEADLINE = 'after_deadline',
     NEVER = 'never',
 }


### PR DESCRIPTION
## New Features

+ Added the "Show Results to Participants: After deadline" option.

## Improvements

* Improved the layout of the "Show Results to Participants" option.

![image](https://github.com/Morphclue/apollusia/assets/4145923/245570e7-6fac-4c4a-803a-9095cfb4f410)
