### PR TITLE
Fix unknown change events

### DIFF
--- a/apps/backend/src/poll/poll/poll.controller.ts
+++ b/apps/backend/src/poll/poll/poll.controller.ts
@@ -20,6 +20,7 @@ import {
   Headers,
   NotFoundException,
   Param,
+  ParseArrayPipe,
   ParseBoolPipe,
   Post,
   Put,
@@ -98,7 +99,10 @@ export class PollController {
     }
 
     @Post(':id/events')
-    async postEvents(@Param('id', ObjectIdPipe) id: Types.ObjectId, @Body() pollEvents: PollEventDto[]): Promise<PollEvent[]> {
+    async postEvents(
+      @Param('id', ObjectIdPipe) id: Types.ObjectId,
+      @Body(new ParseArrayPipe({items: PollEventDto})) pollEvents: PollEventDto[],
+    ): Promise<PollEvent[]> {
         const poll = await this.pollService.getPoll(id);
         if (!poll) {
             throw new NotFoundException(id);

--- a/apps/backend/src/poll/poll/poll.service.ts
+++ b/apps/backend/src/poll/poll/poll.service.ts
@@ -235,7 +235,7 @@ export class PollService implements OnModuleInit {
       if (!oldEvent) {
         return false;
       }
-      return oldEvent.start.valueOf() !== new Date(event.start).valueOf() || oldEvent.end.valueOf() !== new Date(event.end).valueOf();
+      return oldEvent.start.valueOf() !== event.start.valueOf() || oldEvent.end.valueOf() !== event.end.valueOf();
     });
     if (updatedEvents.length > 0) {
       for (const event of updatedEvents) {

--- a/apps/backend/src/poll/poll/poll.service.ts
+++ b/apps/backend/src/poll/poll/poll.service.ts
@@ -235,7 +235,7 @@ export class PollService implements OnModuleInit {
       if (!oldEvent) {
         return false;
       }
-      return oldEvent.start.valueOf() !== event.start.valueOf() || oldEvent.end.valueOf() !== event.end.valueOf();
+      return oldEvent.start.valueOf() !== new Date(event.start).valueOf() || oldEvent.end.valueOf() !== new Date(event.end).valueOf();
     });
     if (updatedEvents.length > 0) {
       for (const event of updatedEvents) {
@@ -398,7 +398,7 @@ export class PollService implements OnModuleInit {
       $or: events.map(e => ({['selection.' + e._id]: {$exists: true}})),
     };
     await this.participantModel.updateMany(filter, {
-      $unset: events.map(e => 'selection.' + e._id),
+      $unset: events.reduce((acc, e) => ({...acc, ['selection.' + e._id]: ''}), {})
     }, {timestamps: false}).exec();
   }
 

--- a/apps/backend/src/poll/poll/poll.service.ts
+++ b/apps/backend/src/poll/poll/poll.service.ts
@@ -398,7 +398,7 @@ export class PollService implements OnModuleInit {
       $or: events.map(e => ({['selection.' + e._id]: {$exists: true}})),
     };
     await this.participantModel.updateMany(filter, {
-      $unset: events.reduce((acc, e) => ({...acc, ['selection.' + e._id]: ''}), {})
+      $unset: events.reduce((acc, e) => ({...acc, ['selection.' + e._id]: true}), {})
     }, {timestamps: false}).exec();
   }
 

--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.html
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.html
@@ -74,7 +74,6 @@
           [participants]="participants"
           [isAdmin]="isAdmin"
           [canParticipate]="!closedReason"
-          [showResults]="!hiddenReason"
           [token]="token"
           [bestOption]="bestOption"
         ></apollusia-table>

--- a/apps/frontend/src/app/poll/table/table.component.html
+++ b/apps/frontend/src/app/poll/table/table.component.html
@@ -55,7 +55,6 @@
           </th>
         </tr>
       }
-      @if (showResults) {
         @for (participant of participants; track participant) {
           <tr>
             <th>
@@ -133,7 +132,6 @@
           }
           <td class="border-0"></td>
         </tr>
-      }
       @if (poll && isAdmin) {
         <tr>
           <th>Select Events</th>

--- a/apps/frontend/src/app/poll/table/table.component.ts
+++ b/apps/frontend/src/app/poll/table/table.component.ts
@@ -17,7 +17,6 @@ export class TableComponent implements OnInit {
   @Input() participants: Participant[] = [];
   @Input() isAdmin: boolean = false;
   @Input() canParticipate: boolean = false;
-  @Input() showResults: boolean = false;
   @Input() token: string;
   @Input() bestOption: number = 1;
 

--- a/libs/types/src/lib/schema/poll-event.schema.ts
+++ b/libs/types/src/lib/schema/poll-event.schema.ts
@@ -1,7 +1,7 @@
 import {Ref} from '@mean-stream/nestx/ref';
 import {Prop, Schema, SchemaFactory} from '@nestjs/mongoose';
 import {ApiProperty} from '@nestjs/swagger';
-import {IsDate, IsString} from 'class-validator';
+import {IsDate, IsOptional, IsString} from 'class-validator';
 import {Types} from 'mongoose';
 
 import {Poll} from './poll.schema';
@@ -28,8 +28,9 @@ export class PollEvent {
     end: Date;
 
     @Prop()
+    @IsOptional()
     @IsString()
-    note: string;
+    note?: string;
 }
 
 export const PollEventSchema = SchemaFactory.createForClass(PollEvent);


### PR DESCRIPTION
# Context
Last time I moved some dates, I've noticed that they don't get updated anymore into an unknown state.
According to the usage of the [$unset](https://www.mongodb.com/docs/manual/reference/operator/update/unset/) doc from MongoDB they use ```{ $unset: { quantity: "", instock: "" } }``` with an empty string. Even if the specific declaration of the value is not necessary, I have used it as a guide.

Furthermore I've noticed that `event` inside the filter was of type string. Therefore a correct comparison wasn't possible.