### PR TITLE
Fix line break in card url

### DIFF
--- a/apps/frontend/src/app/core/info-table/info-table.component.html
+++ b/apps/frontend/src/app/core/info-table/info-table.component.html
@@ -34,12 +34,14 @@
       <i class="bi-link" ngbTooltip="Link"></i>
     </th>
     <td>
-      <a routerLink="." class="text-truncate">{{ url }}</a>
-      &nbsp;
-      <button class="btn p-0 btn-link bi-clipboard" ngbTooltip="Copy to clipboard"
-              (click)="copyToClipboard()"></button>
-      <button class="btn p-0 btn-link bi-envelope-at" ngbTooltip="Share via email"
-              (click)="draftEmail()"></button>
+      <div class="d-flex align-items-center">
+        <a routerLink="." class="break-link">{{ url }}</a>
+        &nbsp;
+        <button class="btn p-0 btn-link bi-clipboard" ngbTooltip="Copy to clipboard"
+                (click)="copyToClipboard()"></button>
+        <button class="btn p-0 btn-link bi-envelope-at" ngbTooltip="Share via email"
+                (click)="draftEmail()"></button>
+      </div>
     </td>
   </tr>
   @if (stats) {

--- a/apps/frontend/src/app/core/info-table/info-table.component.scss
+++ b/apps/frontend/src/app/core/info-table/info-table.component.scss
@@ -3,3 +3,7 @@ table > tr > th:first-child {
   padding: 0;
   vertical-align: top;
 }
+
+.break-link {
+  word-break: break-word;
+}

--- a/apps/frontend/src/app/dashboard/card/card.component.html
+++ b/apps/frontend/src/app/dashboard/card/card.component.html
@@ -14,7 +14,7 @@
       </div>
     </div>
   </div>
-  <div class="card-body p-2">
+  <div class="card-body">
     <apollusia-info-table [poll]="poll" [description]="!small" [stats]="true"></apollusia-info-table>
   </div>
 </div>

--- a/apps/frontend/src/app/dashboard/card/card.component.html
+++ b/apps/frontend/src/app/dashboard/card/card.component.html
@@ -14,7 +14,7 @@
       </div>
     </div>
   </div>
-  <div class="card-body">
+  <div class="card-body p-2">
     <apollusia-info-table [poll]="poll" [description]="!small" [stats]="true"></apollusia-info-table>
   </div>
 </div>


### PR DESCRIPTION
# Context 
Currently the line break isn't correct for medium devices (#161).
With this change it will be fixed:
![image](https://github.com/Morphclue/apollusia/assets/43741877/85651a5a-09f1-466a-854e-4a5b80f95667)



