### PR TITLE
Fix #194: Update Sum row immediately when user making changes

### DIFF
--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.html
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.html
@@ -76,6 +76,7 @@
           [canParticipate]="!closedReason"
           [token]="token"
           [bestOption]="bestOption"
+          (changed)="onTableChange()"
         ></apollusia-table>
       }
       @case ("events") {

--- a/apps/frontend/src/app/poll/choose-events/choose-events.component.ts
+++ b/apps/frontend/src/app/poll/choose-events/choose-events.component.ts
@@ -204,4 +204,13 @@ export class ChooseEventsComponent implements OnInit {
   private userVoted(): boolean {
     return this.participants?.some(participant => participant.token === this.token) ?? false;
   }
+
+  onTableChange() {
+    if(this.poll) {
+      this.pollService.getEvents(this.poll._id).subscribe((events)=>{
+        this.pollEvents = events;
+        this.updateHelpers();
+      })
+    }
+  }
 }


### PR DESCRIPTION
Fixes: #194 
The 'Sum' row wasn't updated immediately when the user made changes because we didn't update the `pollEvents` accordingly. This diff updates `pollEvents`  in the parent `ChooseEventsComponent` component by calling `pollService` when the table component data changes.

## Test run


![Screen Recording 2024-10-29 at 00 14 00](https://github.com/user-attachments/assets/f50ecda0-d467-40ca-bd3b-d1f79ca5136d)

