### PR TITLE
Docker Updates

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:lts-slim as builder
+FROM node:lts-slim AS builder
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN corepack pnpm install --frozen-lockfile
+RUN CYPRESS_INSTALL_BINARY=0 corepack pnpm install --frozen-lockfile
 COPY . .
 RUN corepack pnpm run build:backend
 
@@ -9,6 +9,6 @@ FROM node:lts-slim
 WORKDIR /app
 COPY --from=builder /app/dist/apps/backend/ ./
 ENV NODE_ENV=production
-RUN corepack pnpm install # --frozen-lockfile
+RUN CYPRESS_INSTALL_BINARY=0 corepack pnpm install --frozen-lockfile
 EXPOSE 3000
 CMD node main.js

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-slim as builder
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN corepack pnpm install --frozen-lockfile
+RUN CYPRESS_INSTALL_BINARY=0 corepack pnpm install --frozen-lockfile
 COPY . .
 ARG APP_VERSION
 RUN APP_VERSION=$APP_VERSION corepack pnpm run build:frontend

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,6 @@
-version: '3'
 services:
   database:
-    image: mongo
+    image: mongo:7
     ports:
       - "27017:27017"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3'
 services:
   database:
-    image: mongo
+    image: mongo:7
     ports:
       - "27017:27017"
     volumes:


### PR DESCRIPTION
- Backend and frontend no longer installs cypress -- faster build and smaller image
- Set a consistent version for MongoDB. If it upgrades too quickly (e.g. in my case from 6 to 8), it will fail to launch because the [feature compatibility version](https://www.mongodb.com/docs/v7.0/reference/command/setFeatureCompatibilityVersion/) does not match any more.