### PR TITLE
Keycloak relative url /auth

### DIFF
--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ export const environment = {
   production: true,
   backendURL: '/api/v1',
   keycloak: {
-    url: 'https://apollusia.com/auth',
+    url: '/auth',
     realm: 'apollusia',
     clientId: 'web',
   },


### PR DESCRIPTION
# Context
Use relative url, which is necessary for deployments other than on apollusia.com