### PR TITLE
Remove uuid in favor of crypto.randomUUID()

### DIFF
--- a/apps/backend/src/token/token/token.service.ts
+++ b/apps/backend/src/token/token/token.service.ts
@@ -2,8 +2,6 @@ import {Participant, Poll} from '@apollusia/types';
 import {Injectable} from '@nestjs/common';
 import {InjectModel} from '@nestjs/mongoose';
 import {Model} from 'mongoose';
-import {v4 as uuidv4} from 'uuid';
-
 
 @Injectable()
 export class TokenService {
@@ -14,11 +12,11 @@ export class TokenService {
     }
 
     generateToken(): any {
-        return {token: uuidv4()};
+        return {token: crypto.randomUUID()};
     }
 
     async regenerateToken(token: string): Promise<any> {
-        const newToken = uuidv4();
+        const newToken = crypto.randomUUID();
         await this.pollModel.updateMany({adminToken: token}, {adminToken: newToken}).exec();
         await this.participantModel.updateMany({token}, {token: newToken}).exec();
         return {token: newToken};

--- a/apps/frontend/src/app/core/services/token.service.ts
+++ b/apps/frontend/src/app/core/services/token.service.ts
@@ -1,8 +1,7 @@
 import {HttpClient} from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 import {map, tap} from 'rxjs/operators';
-import * as uuid from 'uuid';
 
 import {StorageService} from './storage.service';
 import {environment} from '../../../environments/environment';
@@ -25,7 +24,7 @@ export class TokenService {
       this.currentToken = stored;
       return stored;
     }
-    const newToken = uuid.v4();
+    const newToken = crypto.randomUUID();
     this.setToken(newToken);
     return newToken;
   }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
-    "uuid": "^11.1.0",
     "web-push": "^3.6.7",
     "zone.js": "0.15.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
@@ -10582,10 +10579,6 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -24162,8 +24155,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
This pull request refactors token generation in both the backend and frontend services to use the native `crypto.randomUUID()` API instead of the third-party `uuid` package. As a result, the `uuid` dependency is removed from the project, simplifying the codebase and reducing external dependencies.

**Token generation refactor:**

* Replaced usage of `uuid.v4()` with the native `crypto.randomUUID()` in `TokenService` in both backend (`apps/backend/src/token/token/token.service.ts`) and frontend (`apps/frontend/src/app/core/services/token.service.ts`). [[1]](diffhunk://#diff-6b7cb7b02e925041a867983252c5eca4c0dd2e2b860fcbbb51af6460d562f721L17-R19) [[2]](diffhunk://#diff-0b468a6d2f257bbdcc3f9540ebae1d8ba369e6e58540d3d5aa795e4be9c7786eL28-R27)

**Dependency cleanup:**

* Removed the `uuid` package from `package.json`, `pnpm-lock.yaml`, and all related import statements. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L141) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL192-L194) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10586-L10589) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24166-L24167) [[5]](diffhunk://#diff-6b7cb7b02e925041a867983252c5eca4c0dd2e2b860fcbbb51af6460d562f721L5-L6) [[6]](diffhunk://#diff-0b468a6d2f257bbdcc3f9540ebae1d8ba369e6e58540d3d5aa795e4be9c7786eL5)